### PR TITLE
Added rsync options for better handling of sparse files and hard links

### DIFF
--- a/rpi-clone
+++ b/rpi-clone
@@ -35,7 +35,7 @@ VERSION=1.6a
 
 PGM=`basename $0`
 
-RSYNC_OPTIONS="--force -rltWDEgoptx"
+RSYNC_OPTIONS="--force -rltWDEgoptxaHS"
 
 # Where to mount the disk filesystems to be rsynced.
 CLONE=/mnt/clone


### PR DESCRIPTION
By including -aH, hard links are preserved in the backup copy. -S handles sparse files in a reasonable way (instead of creating large regular files with lots of zeros). For very large sparse files which changes regularly, one would actually want the first copy to specify -S, but subsequent copies should use "--inplace" instead (not both!). Oh well, this works for now. :)